### PR TITLE
Directly open the result in a browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "open 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -654,6 +655,14 @@ dependencies = [
 name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "open"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "openssl"
@@ -1532,6 +1541,7 @@ dependencies = [
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+"checksum open 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eedfa0ca7b54d84d948bfd058b8f82e767d11f362dd78c36866fd1f69c175867"
 "checksum openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)" = "5a0d6b781aac4ac1bd6cafe2a2f0ad8c16ae8e1dd5184822a16c50139f8838d9"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.43 (registry+https://github.com/rust-lang/crates.io-index)" = "33c86834957dd5b915623e94f2f4ab2c70dd8f6b70679824155d5ae21dbd495d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 clap="2.31"
 urlparse = "0.7"
+open = "1.2.2"
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 
+extern crate open;
+
 use clap::{App, AppSettings, Arg, SubCommand};
 
 mod compiler;
@@ -55,6 +57,11 @@ fn main() {
                     Arg::with_name("url")
                         .long("url")
                         .help("get an URL for given compilation"),
+                )
+                .arg(
+                    Arg::with_name("open")
+                        .long("open")
+                        .help("open the result in a browser"),
                 )
                 .arg(
                     Arg::with_name("id")
@@ -114,6 +121,13 @@ fn main() {
         if matches.is_present("url") {
             let url = get_url(&src, &host, &compiler, &args);
             println!("URL: {}", url);
+        }
+        if matches.is_present("open") {
+            let url = get_url(&src, &host, &compiler, &args);
+            match open::that(url) {
+                Ok(_) => println!("Opened result in browser"),
+                Err(_e) => println!("Failed to open the compilation in the browser."),
+            };
         }
         let asm = compile(client, &host, src, compiler, args);
         println!("{}", asm);


### PR DESCRIPTION
This pull request adds an option `cce compile --open ...` to directly open the result in a browser.

Please note that I am not a Rust developer, so please ensure that I haven't made any mistakes in this regard.